### PR TITLE
feat: Added support for RoleBinding/ClusterRoleBinding Group subjects.

### DIFF
--- a/charts/library/common/schemas/rbac.json
+++ b/charts/library/common/schemas/rbac.json
@@ -102,16 +102,16 @@
                 },
                 "kind": {
                   "type": "string",
-                  "description": "The kind of the referenced subject."
+                  "description": "The kind of the referenced subject. Supported values: ServiceAccount, User, Group."
                 },
                 "namespace": {
-                  "type": "string",
-                  "description": "The namespace of the referenced subject."
+                  "type": ["string", null],
+                  "description": "The namespace of the referenced subject. Do not define if kind is User or Group."
                 }
               },
               "oneOf": [
                 {"required": ["identifier"]},
-                {"required": ["name", "kind", "namespace"]}
+                {"required": ["name", "kind"]}
               ]
             }
           }

--- a/charts/library/common/schemas/rbac.json
+++ b/charts/library/common/schemas/rbac.json
@@ -105,7 +105,7 @@
                   "description": "The kind of the referenced subject. Supported values: ServiceAccount, User, Group."
                 },
                 "namespace": {
-                  "type": ["string", null],
+                  "type": "string",
                   "description": "The namespace of the referenced subject. Do not define if kind is User or Group."
                 }
               },

--- a/charts/library/common/templates/classes/_rolebinding.tpl
+++ b/charts/library/common/templates/classes/_rolebinding.tpl
@@ -25,7 +25,13 @@ This template serves as a blueprint for generating RoleBinding objects in Kubern
         {{- $_ := set $subject "kind" "ServiceAccount" -}}
         {{- $_ := set $subject "namespace" $rootContext.Release.Namespace -}}
         {{- $subjects = mustAppend $subjects $subject -}}
+      {{- else if dict "kind" = "Group" -}}
+        {{- $subject := dict "name" .name "kind" .kind -}}
+        {{- $subjects = mustAppend $subjects $subject -}}
       {{- else -}}
+        {{- if not .namespace }}
+          {{- fail (printf "No namespace provided for subject in rolebinding '%s'. Please provide a namespace." $roleBindingObject.name) -}}
+        {{- end -}}
         {{- $subject := dict "name" .name "kind" .kind "namespace" .namespace -}}
         {{- $subjects = mustAppend $subjects $subject -}}
       {{- end -}}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -866,3 +866,5 @@ rbac:
   #       - kind: ServiceAccount
   #         name: test
   #         namespace: "{{ .Release.Namespace }}"
+  #       - kind: Group
+  #         name: oidc:/test-user


### PR DESCRIPTION
### Description of the change

Developers using the AppTemplate in enterprise or homelab environments with OIDC authentication may want to support Group subjects in `RoleBinding` or `ClusterRoleBinding` resources. This allows access to be granted based on OIDC group membership.

#### Added

* Added support for Group subjects for RoleBinding and ClusterRoleBinding resources.

### Benefits

* Enables developers who have OIDC in their cluster to provide OIDC Group Access to designated resources.

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [ ] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.