### PR TITLE
docs(app-template): add env examples

### DIFF
--- a/docs/app-template/howto/environment-variables.md
+++ b/docs/app-template/howto/environment-variables.md
@@ -1,0 +1,57 @@
+# Environment Variables
+
+## Set environment variables directly
+
+Setting environment variables for a container can be done in several ways. The simplest is to define them directly in the container settings using the `env` field:
+
+
+```yaml
+    containers:
+      main:
+        env:
+          - name: ENV_VAR_NAME
+            value: "value"
+          - name: ANOTHER_ENV_VAR
+            value: "another value"
+```
+
+## ConfigMaps
+
+You can also create a ConfigMap for shared environment variables:
+
+```yaml
+configMaps:
+  app-config:
+    data:
+      ENV_VAR_NAME: "value"
+      ANOTHER_ENV_VAR: "another value"
+
+controllers:
+  main:    
+    containers:
+      main:
+        envFrom:
+          - configMapRef:
+              # Reference an app-template ConfigMap
+              identifier: app-config
+
+              # Reference a preexisting ConfigMap
+              # name: preexisting-configmap-name
+```
+
+## Secrets
+
+Secrets are managed in the same way:
+
+```yaml
+secrets:
+  app-secrets:
+    SECRET_KEY: "s3cr3t"
+controllers:
+  main:
+    containers:
+      main:
+        envFrom:
+          - secretRef:
+              identifier: app-secrets
+```


### PR DESCRIPTION
### Description of the change
Adds examples to documentation for environment variables
- Directly in container with `env`
- From a `ConfigMap`
- From a `Secret`

#### Removed
:x: 

#### Fixed
:x: 

#### Added
Added examples in documentation

#### Changed
:x: 
### Benefits
Better documentation

### Possible drawbacks
:x: 

### Applicable issues
:x: 

## Additional information
Just providing the example I was looking for in the docs after I made it.

Thanks for making and maintaining this excellent project! :rocket: 

## Checklist
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.