### PR TITLE
feat(all): Add support for image digest

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 4.2.0
+version: 4.2.1
 kubeVersion: ">=1.28.0-0"
 keywords:
   - common
@@ -18,22 +18,4 @@ annotations:
   artifacthub.io/changes: |-
     - kind: added
       description: |-
-        Allow Helm templating for existingClaim field in persistence items.
-    - kind: added
-      description: |-
-        Allow Helm templating for subPath and Path fields in persistence items.
-    - kind: added
-      description: |-
-        Allow mounting of container images as persistence items in Kubernetes >= 1.33.
-      links:
-        - name: Kubernetes documentation
-          url: https://kubernetes.io/docs/concepts/storage/volumes/#image
-    - kind: added
-      description: |-
-        Allow configuring a portRange instead of a single port in Services.
-    - kind: fixed
-      description: |-
-        Fixed advancedMounts validation to not fail when persistence item is disabled.
-    - kind: fixed
-      description: |-
-        Allow probes to be configured when no services are enabled.
+        Add support for image digest. Enables use of `digestReflectionPolicy` in Flux CD

--- a/charts/library/common/templates/lib/container/_validate.tpl
+++ b/charts/library/common/templates/lib/container/_validate.tpl
@@ -7,7 +7,7 @@ Validate container values
   {{- $containerObject := .containerObject -}}
 
   {{- if not (kindIs "map" $containerObject.image)  -}}
-    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s,container %s)" $controllerObject.identifier $containerObject.identifier  $containerObject.identifier) }}
   {{- end -}}
 
   {{- if empty (dig "image" "repository" nil $containerObject) -}}
@@ -15,6 +15,8 @@ Validate container values
   {{- end -}}
 
   {{- if empty (dig "image" "tag" nil $containerObject) -}}
-    {{- fail (printf "No image tag specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+      {{- if empty (dig "image" "digest" nil $containerObject) -}}
+        {{- fail (printf "No image tag specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/container/_validate.tpl
+++ b/charts/library/common/templates/lib/container/_validate.tpl
@@ -7,7 +7,7 @@ Validate container values
   {{- $containerObject := .containerObject -}}
 
   {{- if not (kindIs "map" $containerObject.image)  -}}
-    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s,container %s)" $controllerObject.identifier $containerObject.identifier) }}
+    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
   {{- end -}}
 
   {{- if empty (dig "image" "repository" nil $containerObject) -}}

--- a/charts/library/common/templates/lib/container/_validate.tpl
+++ b/charts/library/common/templates/lib/container/_validate.tpl
@@ -16,7 +16,7 @@ Validate container values
 
   {{- if empty (dig "image" "tag" nil $containerObject) -}}
       {{- if empty (dig "image" "digest" nil $containerObject) -}}
-        {{- fail (printf "No image tag specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+        {{- fail (printf "No image tag or digest specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
       {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/container/_validate.tpl
+++ b/charts/library/common/templates/lib/container/_validate.tpl
@@ -7,7 +7,7 @@ Validate container values
   {{- $containerObject := .containerObject -}}
 
   {{- if not (kindIs "map" $containerObject.image)  -}}
-    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s,container %s)" $controllerObject.identifier $containerObject.identifier  $containerObject.identifier) }}
+    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s,container %s)" $controllerObject.identifier $containerObject.identifier) }}
   {{- end -}}
 
   {{- if empty (dig "image" "repository" nil $containerObject) -}}

--- a/charts/library/common/templates/lib/container/_valuesToObject.tpl
+++ b/charts/library/common/templates/lib/container/_valuesToObject.tpl
@@ -50,6 +50,20 @@ Convert container values to an object
     {{- $_ := set $objectValues.image "tag" $imageTag -}}
   {{- end -}}
 
+  {{- /* Process image digests */ -}}
+  {{- if kindIs "map" $objectValues.image -}}
+    {{- $imageDigest := dig "image" "digest" "" $objectValues -}}
+    {{- /* Convert float64 image digests to string */ -}}
+    {{- if kindIs "float64" $imageDigest -}}
+      {{- $imageDigest = $imageDigest | toString -}}
+    {{- end -}}
+
+    {{- /* Process any templates in the digest */ -}}
+    {{- $imageDigest = tpl $imageDigest $rootContext -}}
+
+    {{- $_ := set $objectValues.image "digest" $imageDigest -}}
+  {{- end -}}
+
   {{- /* Return the container object */ -}}
   {{- $objectValues | toYaml -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/container/fields/_image.tpl
+++ b/charts/library/common/templates/lib/container/fields/_image.tpl
@@ -8,8 +8,13 @@ Image used by the container.
 
   {{- $imageRepo := $containerObject.image.repository -}}
   {{- $imageTag := $containerObject.image.tag -}}
+  {{- $imageDigest := $containerObject.image.digest -}}
 
-  {{- if and $imageRepo $imageTag -}}
+  {{- if and $imageRepo $imageDigest -}}
+    {{- printf "%s@%s" $imageRepo $imageDigest -}}
+  {{- else if and $imageRepo $imageTag -}}
     {{- printf "%s:%s" $imageRepo $imageTag -}}
+  {{- else if and $imageRepo $imageTag $imageDigest -}}
+    {{- printf "%s@%s" $imageRepo $imageDigest -}}
   {{- end -}}
 {{- end -}}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -232,6 +232,8 @@ controllers: {}
 #         repository:
 #         # -- Override the image tag for the containers
 #         tag:
+#         # -- Override the image digest for the containers
+#         digest:
 #         # -- Override the image pull policy for the containers
 #         pullPolicy:
 #       # -- Override the command(s) for the containers
@@ -261,6 +263,8 @@ controllers: {}
 #           repository:
 #           # -- image tag
 #           tag:
+#           # -- image digest
+#           digest:
 #           # -- image pull policy
 #           pullPolicy:
 

--- a/charts/other/app-template/Chart.yaml
+++ b/charts/other/app-template/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A common powered chart template. This can be useful for small projects that don't have their own chart.
 name: app-template
-version: 4.2.0
+version: 4.2.1
 kubeVersion: ">=1.28.0-0"
 maintainers:
   - name: bjw-s
@@ -10,16 +10,16 @@ maintainers:
 dependencies:
   - name: common
     repository: https://bjw-s-labs.github.io/helm-charts
-    version: 4.2.0
+    version: 4.2.1
 sources:
   - https://github.com/bjw-s-labs/helm-charts
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: |-
-        Upgraded the common library to v4.2.0
+        Upgraded the common library to v4.2.1
       links:
         - name: Upgrade notes
           url: https://bjw-s-labs.github.io/helm-charts/docs/app-template/upgrade-instructions/
         - name: Detailed release notes
-          url: https://github.com/bjw-s-labs/helm-charts/releases/tag/common-4.2.0
+          url: https://github.com/bjw-s-labs/helm-charts/releases/tag/common-4.2.1


### PR DESCRIPTION
### Description of the change
Add support for image digest in the container
If you're using flux image automation and you want to use [digest reflection](https://fluxcd.io/flux/components/image/imagepolicies/#digest-reflection), this field is required.

Example scenario:

You're using https://github.com/home-operations/containers/pkgs/container/plex image in your helm release and a new build version is released with a new digest under the same patch version.

Your plex server is saying an update is available but your image policy in flux cannot pick it up because it does not see the new version without the `imageDigestionPolicy` feature.

By adding a digest, image automation will pick up the new version and update the pod in your cluster.

With this change, if both tag and digest are supplied, digest takes precedence as it's more specific. If only tag is supplied, the digest is ignored.

What digest will look like in `values.yaml`:

```
controllers:
  plex:
    containers:
      app:
            image:
              repository: ghcr.io/home-operations/plex # {"$imagepolicy": "flux-system:plex:name"}
              tag: 1.42.1 # {"$imagepolicy": "flux-system:plex:tag"}
              digest: sha256:d361aef8d6e1072cf18c0d54ded39f5e7f5fcc0f9084e6e427fb5373dbf12edb # {"$imagepolicy": "flux-system:plex:digest"}
```

#### Added
Support for image digest value

#### Changed
Error message when tag and digest are missing has been edited to include `digest`

### Benefits
Anyone using image automation in flux or similar from other GitOps tools will be able to get the latest build number versions of images when the patch version doesn't change

### Possible drawbacks
Can't think of any, happy to hear alternative views

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
