### PR TITLE
Remove outdated nameOverride example from values

### DIFF
--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -507,9 +507,6 @@ service:
   #   # -- Enables or disables the service
   #   enabled: true
 
-  #   # -- Override the name suffix that is used for this service
-  #   nameOverride: ""
-
   #   # -- Configure which controller this service should target
   #   controller: main
 


### PR DESCRIPTION
Thank you for such a great project !


I believe nameOverride is not correct option in the service. When I've tried it i got: 

```
Error: values don't meet the specifications of the schema(s) in the following chart(s): app-template:         
- at '/service/app': 'allOf' failed      
  - at '/service/app': additional properties 'nameOverride' not allowed `
```

Looking at the schema, I also cannot see it there:

https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/schemas/service.json