### PR TITLE
fix(common): remove useless blank lines and spaces in httpRoute

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 4.6.2
-kubeVersion: ">=1.28.0-0"
+version: 4.6.3
+kubeVersion: '>=1.28.0-0'
 keywords:
   - common
   - library

--- a/charts/library/common/templates/classes/_route.tpl
+++ b/charts/library/common/templates/classes/_route.tpl
@@ -35,6 +35,8 @@ metadata:
   {{- end }}
   {{- with $annotations }}
   annotations:
+    artifacthub.io/changes: |
+      fix: remove a uesless blank line and some spaces
     {{- range $key, $value := . }}
     {{- printf "%s: %s" $key (tpl $value $rootContext | toYaml ) | nindent 4 }}
     {{- end }}
@@ -62,69 +64,74 @@ spec:
   {{- end }}
   rules:
   {{- range $routeObject.rules }}
-    - {{- if .name }}
+    - {{ if .name -}}
       name: {{ tpl .name $rootContext }}
-      {{- end }}
-      backendRefs:
+      {{- printf "\n      " -}}
+      {{- end }}backendRefs:
       {{- if empty .backendRefs }}
-        {{- printf " []" }}
+        []
       {{- else }}
-        {{- range .backendRefs }}
-          {{- $service := dict }}
-          {{- $serviceName := "" }}
-          {{- $servicePort := 0 }}
-          {{- if .name }}
-            {{- $serviceName = tpl .name $rootContext }}
-          {{- else if .identifier }}
-            {{- $service = (include "bjw-s.common.lib.service.getByIdentifier" (dict "rootContext" $rootContext "id" .identifier) | fromYaml ) }}
-            {{- if not $service }}
-              {{- fail (printf "No enabled Service found with this identifier. (route: '%s', identifier: '%s')" $routeObject.identifier .identifier) }}
-            {{- end }}
-            {{- $serviceName = $service.name }}
-          {{- end }}
-          {{- if empty .port }}
-            {{/*- Default to the Service primary port if no port has been specified */}}
-            {{- if $service }}
-              {{- $defaultServicePort := include "bjw-s.common.lib.service.primaryPort" (dict "rootContext" $rootContext "serviceObject" $service) | fromYaml }}
-              {{- if $defaultServicePort }}
-                {{- $servicePort = $defaultServicePort.port }}
-              {{- end }}
-            {{- end }}
-          {{- else }}
-            {{/*- If a port number is given, use that */}}
-            {{- if kindIs "float64" .port }}
-              {{- $servicePort = .port }}
-            {{- else if kindIs "string" .port }}
-              {{/*- If a port name is given, try to resolve to a number */}}
-              {{- $servicePort = include "bjw-s.common.lib.service.getPortNumberByName" (dict "rootContext" $rootContext "serviceID" $service.identifier "portName" .port) }}
-              {{- if not $servicePort }}
-                {{- fail (printf "No enabled Service Port found with this identifier. (route: '%s', service: '%s', identifier: '%s')" $routeObject.identifier $service.identifier .port) }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-      - group: {{ .group | default "" | quote}}
-        kind: {{ .kind | default "Service" }}
-        name: {{ $serviceName }}
-        namespace: {{ .namespace | default $rootContext.Release.Namespace }}
-        {{- if $servicePort }}
-        port: {{ $servicePort }}
+      {{- range .backendRefs }}
+        {{- $service := dict -}}
+        {{- $serviceName := "" -}}
+        {{- $servicePort := 0 -}}
+        {{- if .name -}}
+          {{- $serviceName = tpl .name $rootContext -}}
+        {{- else if .identifier -}}
+          {{- $service = (include "bjw-s.common.lib.service.getByIdentifier" (dict "rootContext" $rootContext "id" .identifier) | fromYaml ) -}}
+          {{- if not $service -}}
+            {{- fail (printf "No enabled Service found with this identifier. (route: '%s', identifier: '%s')" $routeObject.identifier .identifier) -}}
+          {{- end -}}
+          {{- $serviceName = $service.name -}}
+        {{- end -}}
+        {{- if empty .port -}}
+          {{- /* Default to the Service primary port if no port has been specified */ -}}
+          {{- if $service -}}
+            {{- $defaultServicePort := include "bjw-s.common.lib.service.primaryPort" (dict "rootContext" $rootContext "serviceObject" $service) | fromYaml -}}
+            {{- if $defaultServicePort -}}
+              {{- $servicePort = $defaultServicePort.port -}}
+            {{- end -}}
+          {{- end -}}
+        {{- else -}}
+          {{- /* If a port number is given, use that */ -}}
+          {{- if kindIs "float64" .port -}}
+            {{- $servicePort = .port -}}
+          {{- else if kindIs "string" .port -}}
+            {{- /* If a port name is given, try to resolve to a number */ -}}
+            {{- $servicePort = include "bjw-s.common.lib.service.getPortNumberByName" (dict "rootContext" $rootContext "serviceID" $service.identifier "portName" .port) -}}
+            {{- if not $servicePort -}}
+              {{- fail (printf "No enabled Service Port found with this identifier. (route: '%s', service: '%s', identifier: '%s')" $routeObject.identifier $service.identifier .port) -}}
+            {{- end -}}
+          {{- end -}}
         {{- end }}
-        weight: {{ include "bjw-s.common.lib.defaultKeepNonNullValue" (dict "value" .weight "default" 1) }}
-        {{- end }}
+        {{- printf "\n        " -}}
+        - group: {{ .group | default "" | quote }}
+          kind: {{ .kind | default "Service" }}
+          name: {{ $serviceName }}
+          namespace: {{ .namespace | default $rootContext.Release.Namespace }}
+          {{- if $servicePort }}
+          port: {{ $servicePort }}
+          {{- end }}
+          weight: {{ include "bjw-s.common.lib.defaultKeepNonNullValue" (dict "value" .weight "default" 1) }}
+      {{- end }}
       {{- end }}
       {{- if or (eq $routeKind "HTTPRoute") (eq $routeKind "GRPCRoute") }}
         {{- with .matches }}
+      {{- printf "\n      " -}}
       matches: {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .filters }}
+      {{- printf "\n      " -}}
       filters: {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .sessionPersistence }}
+      {{- printf "\n      " -}}
       sessionPersistence: {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- if (eq $routeKind "HTTPRoute") }}
         {{- with .timeouts }}
+      {{- printf "\n      " -}}
       timeouts: {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- I had an issue with httpRoute templating (still valid yaml but with useless blank lines and whitespaces)
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code. (Done)

I used this yaml code which produces the issue:

```yaml
route:
  main:
    enabled: true
    parentRefs:
      - name: your-gateway
        namespace: your-gateway-namespace
    hostnames:
      - subdomain.yourdomain.com
    rules:
      - matches:
          - path:
              type: PathPrefix
              value: /
        backendRefs:
          - group: ''"
            kind: Service
            name: server
            port: 1234
            weight: 1
```

Before the change:

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: release-name
  labels:
    helm.sh/chart: helmchart-123
  namespace: your-namespace
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: your-gateway
      namespace: your-gateway-namespace
  hostnames:
    - "subdomain.yourdomain.com"
  rules:
    -                         # <---
      backendRefs:   # <---
                              # <---
      - group: ""
        kind: Service
        name: server
        namespace: your-namespace
        port: 1234
        weight: 1
      matches:
        - path:
            type: PathPrefix
            value: /
```

After the change:

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: release-name
  labels:
    helm.sh/chart: helmchart-123
  namespace: your-namespace
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: your-gateway
      namespace: your-gateway-namespace
  hostnames:
    - "subdomain.yourdomain.com"
  rules:
    - backendRefs:   # <---
        - group: ""
           kind: Service
           name: server
           namespace: your-namespace
           port: 1234
           weight: 1
      matches:
        - path:
            type: PathPrefix
            value: /
```

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Render the httpRoute cleaner. This will not improve the function of httpRoute just to render it without ueless blank lines or spaces.
-->

#### Fixed
- Clean httpRoute creation

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
