### PR TITLE
feat(common): support image references as strings

### DIFF
--- a/charts/library/common/schemas/containers.json
+++ b/charts/library/common/schemas/containers.json
@@ -190,20 +190,25 @@
   },
 
   "image": {
-    "allOf": [
-      { "$ref": "definitions.json#/imageSpecification" },
+    "oneOf": [
+      { "type": "string" },
       {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "pullPolicy": {
-            "type": "string",
-            "enum": ["Always", "IfNotPresent", "Never"]
-          },
-          "repository": {},
-          "tag": {},
-          "digest": {}
-        }
+        "allOf": [
+          { "$ref": "definitions.json#/imageSpecification" },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "pullPolicy": {
+                "type": "string",
+                "enum": ["Always", "IfNotPresent", "Never"]
+              },
+              "repository": {},
+              "tag": {},
+              "digest": {}
+            }
+          }
+        ]
       }
     ]
   },

--- a/charts/library/common/templates/lib/common/_imageSpecificationToImage.tpl
+++ b/charts/library/common/templates/lib/common/_imageSpecificationToImage.tpl
@@ -6,16 +6,20 @@ Translate an imageSpecification to an image string.
   {{- $rootContext := .rootContext -}}
   {{- $imageSpec := .imageSpec -}}
 
-  {{- $imageRepo := tpl $imageSpec.repository $rootContext -}}
-  {{- $imageTag := tpl (default "" $imageSpec.tag) $rootContext -}}
-  {{- $imageDigest := tpl (default "" $imageSpec.digest) $rootContext -}}
+  {{- if kindIs "string" $imageSpec -}}
+    {{- tpl $imageSpec $rootContext -}}
+  {{- else -}}
+    {{- $imageRepo := tpl $imageSpec.repository $rootContext -}}
+    {{- $imageTag := tpl (default "" $imageSpec.tag) $rootContext -}}
+    {{- $imageDigest := tpl (default "" $imageSpec.digest) $rootContext -}}
 
-  {{- $image := $imageRepo -}}
-  {{- if $imageTag -}}
-    {{- $image = printf "%s:%s" $image $imageTag -}}
+    {{- $image := $imageRepo -}}
+    {{- if $imageTag -}}
+      {{- $image = printf "%s:%s" $image $imageTag -}}
+    {{- end -}}
+    {{- if $imageDigest -}}
+      {{- $image = printf "%s@%s" $image $imageDigest -}}
+    {{- end -}}
+    {{- $image -}}
   {{- end -}}
-  {{- if $imageDigest -}}
-    {{- $image = printf "%s@%s" $image $imageDigest -}}
-  {{- end -}}
-  {{- $image -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/container/_validate.tpl
+++ b/charts/library/common/templates/lib/container/_validate.tpl
@@ -6,15 +6,17 @@ Validate container values
   {{- $controllerObject := .controllerObject -}}
   {{- $containerObject := .containerObject -}}
 
-  {{- if not (kindIs "map" $containerObject.image)  -}}
-    {{- fail (printf "Image required to be a dictionary with repository and tag fields. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+  {{- if not (or (kindIs "string" $containerObject.image) (kindIs "map" $containerObject.image)) -}}
+    {{- fail (printf "Image must be a string or a dictionary with repository and tag fields. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
   {{- end -}}
 
-  {{- if empty (dig "image" "repository" nil $containerObject) -}}
-    {{- fail (printf "No image repository specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
-  {{- end -}}
+  {{- if kindIs "map" $containerObject.image -}}
+    {{- if empty (dig "image" "repository" nil $containerObject) -}}
+      {{- fail (printf "No image repository specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+    {{- end -}}
 
-  {{- if and (empty (dig "image" "tag" nil $containerObject)) (empty (dig "image" "digest" nil $containerObject)) -}}
-    {{- fail (printf "No image tag or digest specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+    {{- if and (empty (dig "image" "tag" nil $containerObject)) (empty (dig "image" "digest" nil $containerObject)) -}}
+      {{- fail (printf "No image tag or digest specified for container. (controller %s, container %s)" $controllerObject.identifier $containerObject.identifier) }}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/library/common/test-chart/unittests/container/field_image_test.yaml
+++ b/charts/library/common/test-chart/unittests/container/field_image_test.yaml
@@ -116,3 +116,29 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/mendhak/http-https-echo:latest@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+  - it: string image reference should pass
+    values:
+      - ../_values/controllers_main_default_container.yaml
+    set:
+      controllers.main.containers.main.image: ghcr.io/mendhak/http-https-echo:latest
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/mendhak/http-https-echo:latest
+
+  - it: string image reference with digest should pass
+    values:
+      - ../_values/controllers_main_default_container.yaml
+    set:
+      controllers.main.containers.main.image: ghcr.io/mendhak/http-https-echo@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    documentSelector:
+      path: $[?(@.kind == "Deployment")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/mendhak/http-https-echo@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef


### PR DESCRIPTION
### Description of the change
Support string `image` values.

#### Removed
<!-- Any features that have been removed -->

#### Fixed
<!-- Any functionality that has been fixed -->

#### Added
`image` can now be a normal image reference string

#### Changed
<!-- Any features that have been changed from how they were working before -->

### Benefits
Renovate's docker manager now picks up these references.

### Possible drawbacks

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #632 

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [ ] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.
