### PR TITLE
feat: add hpa compatibility to library-common

### DIFF
--- a/charts/library/common/schemas/controllers.json
+++ b/charts/library/common/schemas/controllers.json
@@ -129,6 +129,41 @@
                 "type": ["integer", "string"]
               }
             }
+          },
+          "horizontalPodAutoscaler": {
+            "description": "HorizontalPodAutoscaler configuration for this controller. Only supported for deployment and statefulset types.",
+            "type": "object",
+            "required": ["maxReplicas"],
+            "properties": {
+              "minReplicas": {
+                "description": "Minimum number of replicas.",
+                "type": "integer",
+                "minimum": 1,
+                "default": 1
+              },
+              "maxReplicas": {
+                "description": "Maximum number of replicas.",
+                "type": "integer",
+                "minimum": 1
+              },
+              "annotations": { "$ref": "definitions.json#/annotations" },
+              "labels": { "$ref": "definitions.json#/labels" },
+              "metrics": {
+                "description": "Metrics to use for scaling decisions.",
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "behavior": {
+                "description": "Scaling behavior configuration.",
+                "type": "object",
+                "properties": {
+                  "scaleDown": { "type": "object" },
+                  "scaleUp": { "type": "object" }
+                }
+              }
+            }
           }
         },
         "allOf": [

--- a/charts/library/common/templates/classes/_horizontalPodAutoscaler.tpl
+++ b/charts/library/common/templates/classes/_horizontalPodAutoscaler.tpl
@@ -1,0 +1,51 @@
+{{/*
+This template serves as a blueprint for HorizontalPodAutoscaler objects that are created
+using the common library.
+*/}}
+{{- define "bjw-s.common.class.horizontalPodAutoscaler" -}}
+  {{- $rootContext := .rootContext -}}
+  {{- $horizontalPodAutoscalerObject := .object -}}
+
+  {{- $labels := merge
+    (dict "app.kubernetes.io/controller" $horizontalPodAutoscalerObject.controller)
+    ($horizontalPodAutoscalerObject.labels | default dict)
+    (include "bjw-s.common.lib.metadata.allLabels" $rootContext | fromYaml)
+  -}}
+  {{- $annotations := merge
+    ($horizontalPodAutoscalerObject.annotations | default dict)
+    (include "bjw-s.common.lib.metadata.globalAnnotations" $rootContext | fromYaml)
+  -}}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $horizontalPodAutoscalerObject.name }}
+  {{- with $labels }}
+  labels:
+    {{- range $key, $value := . }}
+      {{- printf "%s: %s" $key (tpl $value $rootContext | toYaml ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- with $annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+      {{- printf "%s: %s" $key (tpl $value $rootContext | toYaml ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  namespace: {{ $rootContext.Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ $horizontalPodAutoscalerObject.targetApiVersion }}
+    kind: {{ $horizontalPodAutoscalerObject.targetKind }}
+    name: {{ $horizontalPodAutoscalerObject.targetName }}
+  minReplicas: {{ $horizontalPodAutoscalerObject.minReplicas | default 1 }}
+  maxReplicas: {{ $horizontalPodAutoscalerObject.maxReplicas }}
+  {{- with $horizontalPodAutoscalerObject.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $horizontalPodAutoscalerObject.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/library/common/templates/lib/horizontalpodautoscaler/_validate.tpl
+++ b/charts/library/common/templates/lib/horizontalpodautoscaler/_validate.tpl
@@ -1,0 +1,15 @@
+{{/*
+Validate HorizontalPodAutoscaler values
+*/}}
+{{- define "bjw-s.common.lib.horizontalPodAutoscaler.validate" -}}
+  {{- $rootContext := .rootContext -}}
+  {{- $horizontalPodAutoscalerObject := .object -}}
+
+  {{- if empty (get $horizontalPodAutoscalerObject "controller") -}}
+    {{- fail (printf "controller reference is required for HorizontalPodAutoscaler. (HorizontalPodAutoscaler %s)" $horizontalPodAutoscalerObject.identifier) -}}
+  {{- end -}}
+
+  {{- if empty (get $horizontalPodAutoscalerObject "maxReplicas") -}}
+    {{- fail (printf "maxReplicas is required for HorizontalPodAutoscaler. (HorizontalPodAutoscaler %s)" $horizontalPodAutoscalerObject.identifier) -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/library/common/templates/render/_controllers.tpl
+++ b/charts/library/common/templates/render/_controllers.tpl
@@ -44,5 +44,21 @@ Renders the controller objects required by the chart.
       {{- include "bjw-s.common.lib.podDisruptionBudget.validate" (dict "rootContext" $rootContext "object" $podDisruptionBudgetObject) -}}
       {{- include "bjw-s.common.class.podDisruptionBudget" (dict "rootContext" $rootContext "object" $podDisruptionBudgetObject) | nindent 0 -}}
     {{- end -}}
+
+    {{- if $controllerObject.horizontalPodAutoscaler -}}
+      {{- /* Resolve the target kind and apiVersion from the controller type */ -}}
+      {{- $targetKind := "" -}}
+      {{- $targetApiVersion := "apps/v1" -}}
+      {{- if eq $controllerObject.type "deployment" -}}
+        {{- $targetKind = "Deployment" -}}
+      {{- else if eq $controllerObject.type "statefulset" -}}
+        {{- $targetKind = "StatefulSet" -}}
+      {{- else -}}
+        {{- fail (printf "horizontalPodAutoscaler is only supported for deployment and statefulset controller types. (controller: %s, type: %s)" $identifier $controllerObject.type) -}}
+      {{- end -}}
+      {{- $horizontalPodAutoscalerObject := (include "bjw-s.common.lib.valuesToObject" (dict "rootContext" $rootContext "id" $identifier "values" (merge (dict "controller" $identifier "forceRename" $controllerObject.name "targetKind" $targetKind "targetApiVersion" $targetApiVersion "targetName" $controllerObject.name) $controllerObject.horizontalPodAutoscaler))) | fromYaml -}}
+      {{- include "bjw-s.common.lib.horizontalPodAutoscaler.validate" (dict "rootContext" $rootContext "object" $horizontalPodAutoscalerObject) -}}
+      {{- include "bjw-s.common.class.horizontalPodAutoscaler" (dict "rootContext" $rootContext "object" $horizontalPodAutoscalerObject) | nindent 0 -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/library/common/test-chart/unittests/controller/field_horizontalPodAutoscaler_test.yaml
+++ b/charts/library/common/test-chart/unittests/controller/field_horizontalPodAutoscaler_test.yaml
@@ -1,0 +1,214 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: controller - fields - horizontalPodAutoscaler
+templates:
+  - common.yaml
+values:
+  - ../_values/controllers_main_default_container.yaml
+
+tests:
+  - it: default should not exist
+    asserts:
+      - not: true
+        containsDocument:
+          apiVersion: autoscaling/v2
+          kind: HorizontalPodAutoscaler
+          name: release-name
+          any: true
+
+  - it: created with maxReplicas
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 10
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: release-name
+
+  - it: created with minReplicas and maxReplicas
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            minReplicas: 3
+            maxReplicas: 10
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 3
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: created with metrics
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 10
+            metrics:
+              - type: Resource
+                resource:
+                  name: cpu
+                  target:
+                    type: Utilization
+                    averageUtilization: 80
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.metrics
+          value:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 80
+
+  - it: created with behavior
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 10
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 300
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.behavior
+          value:
+            scaleDown:
+              stabilizationWindowSeconds: 300
+
+  - it: targets StatefulSet correctly
+    set:
+      controllers:
+        main:
+          type: statefulset
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 5
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: StatefulSet
+            name: release-name
+
+  - it: fails for daemonset controller type
+    set:
+      controllers:
+        main:
+          type: daemonset
+          horizontalPodAutoscaler:
+            maxReplicas: 5
+    asserts:
+      - failedTemplate:
+          errorMessage: "horizontalPodAutoscaler is only supported for deployment and statefulset controller types. (controller: main, type: daemonset)"
+
+  - it: fails when maxReplicas is missing
+    set:
+      controllers:
+        main:
+          horizontalPodAutoscaler:
+            minReplicas: 1
+    asserts:
+      - failedTemplate: {}
+
+  - it: multiple controllers with prefix and suffix
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 10
+        second:
+          prefix: prefix
+          suffix: suffix
+          replicas: null
+          containers:
+            main:
+              image:
+                repository: ghcr.io/mendhak/http-https-echo
+                tag: 31
+          horizontalPodAutoscaler:
+            maxReplicas: 5
+    asserts:
+      - containsDocument:
+          apiVersion: autoscaling/v2
+          kind: HorizontalPodAutoscaler
+          name: release-name-main
+          any: true
+      - containsDocument:
+          apiVersion: autoscaling/v2
+          kind: HorizontalPodAutoscaler
+          name: prefix-release-name-second-suffix
+          any: true
+
+  - it: hpa targets the correct controller by default
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 10
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/controller"]
+          value: main
+
+  - it: created with custom annotations and labels
+    set:
+      controllers:
+        main:
+          replicas: null
+          horizontalPodAutoscaler:
+            maxReplicas: 10
+            annotations:
+              custom-annotation: custom-value
+            labels:
+              custom-label: custom-value
+    documentSelector:
+      path: $[?(@.kind == "HorizontalPodAutoscaler")].metadata.name
+      value: release-name
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: custom-value
+      - equal:
+          path: metadata.labels.custom-label
+          value: custom-value

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -147,6 +147,44 @@ controllers: {}
 #       # minAvailable: 1
 #       # maxUnavailable: 1
 
+#     # -- Horizontal Pod Autoscaler configuration for this controller.
+#     # Only supported for deployment and statefulset controller types.
+#     # -- [[ref]](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+#     horizontalPodAutoscaler:
+#       {}
+#       # -- Maximum number of replicas (required)
+#       # maxReplicas: 10
+#       # -- Minimum number of replicas
+#       # minReplicas: 1
+#       # -- Provide additional annotations which may be required.
+#       # annotations: {}
+#       # -- Provide additional labels which may be required.
+#       # labels: {}
+#       # -- Metrics to use for scaling decisions.
+#       # -- [[ref]](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec)
+#       # metrics:
+#       #   - type: Resource
+#       #     resource:
+#       #       name: cpu
+#       #       target:
+#       #         type: Utilization
+#       #         averageUtilization: 80
+#       # -- Scaling behavior configuration.
+#       # -- [[ref]](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior)
+#       # behavior:
+#       #   scaleDown:
+#       #     stabilizationWindowSeconds: 300
+#       #     policies:
+#       #       - type: Percent
+#       #         value: 10
+#       #         periodSeconds: 60
+#       #   scaleUp:
+#       #     stabilizationWindowSeconds: 0
+#       #     policies:
+#       #       - type: Percent
+#       #         value: 100
+#       #         periodSeconds: 15
+
 
 #     # -- CronJob configuration. Required only when using `controller.type: cronjob`.
 #     # @default -- See below


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->

#### Removed
<!-- Any features that have been removed -->

#### Fixed
<!-- Any functionality that has been fixed -->

#### Added
<!-- Any new features that have been added -->
- HorizontalPodAutoscaler (HPA) template support using autoscaling/v2 API
#### Changed
<!-- Any features that have been changed from how they were working before -->

### Benefits
<!-- What benefits will be realized by the code change? -->
- Enables autoscaling as a first-class feature
### Possible drawbacks
<!-- Describe any known limitations with your change -->
- Only supports deployment and statefulset controller types (by design — HPA doesn't apply to DaemonSet/CronJob/Job)
### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
```yaml 
  controllers:
    main:
      replicas: null  # let HPA manage replicas
      horizontalPodAutoscaler:
        minReplicas: 2
        maxReplicas: 10
        metrics:
          - type: Resource
            resource:
              name: cpu
              target:
                type: Utilization
                averageUtilization: 80
        behavior:
          scaleDown:
            stabilizationWindowSeconds: 300
```
## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
