### PR TITLE
feat(common): Add updateStrategy to DaemonSet (#681)

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -25,3 +25,6 @@ annotations:
     - kind: changed
       description: |-
         Allow setting namespace field on rawResources.
+    - kind: changed
+      description: |-
+        Add to use strategy and rollingUpdate fields on DaemonSet template.

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 5.0.1
+version: 5.0.2
 kubeVersion: ">=1.31.0-0"
 keywords:
   - common

--- a/charts/library/common/schemas/controllers.json
+++ b/charts/library/common/schemas/controllers.json
@@ -74,7 +74,7 @@
           "type": "object"
         },
         "strategy": {
-          "description": "Controller upgrade strategy. For Deployments: `Recreate` or `RollingUpdate`. For StatefulSets: `OnDelete` or `RollingUpdate`. DaemonSets, CronJobs and Jobs ignore this field.",
+          "description": "Controller upgrade strategy. For Deployments: `Recreate` or `RollingUpdate`. For StatefulSets and DaemonSets: `OnDelete` or `RollingUpdate`. CronJobs and Jobs ignore this field.",
           "type": "string"
         },
         "applyDefaultContainerOptionsToInitContainers": {

--- a/charts/library/common/templates/classes/_daemonset.tpl
+++ b/charts/library/common/templates/classes/_daemonset.tpl
@@ -35,6 +35,21 @@ metadata:
   namespace: {{ $rootContext.Release.Namespace }}
 spec:
   revisionHistoryLimit: {{ include "bjw-s.common.lib.defaultKeepNonNullValue" (dict "value" $daemonsetObject.revisionHistoryLimit "default" 3) }}
+  {{- if $daemonsetObject.strategy }}
+  updateStrategy:
+    type: {{ $daemonsetObject.strategy }}
+    {{- with $daemonsetObject.rollingUpdate }}
+      {{- if and (eq $daemonsetObject.strategy "RollingUpdate") (or (hasKey . "surge") (hasKey . "unavailable")) }}
+    rollingUpdate:
+        {{- if hasKey . "unavailable" }}
+      maxUnavailable: {{ .unavailable }}
+        {{- end }}
+        {{- if hasKey . "surge" }}
+      maxSurge: {{ .surge }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/controller: {{ $daemonsetObject.identifier }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -569,7 +569,7 @@ controllers: {}
     # -- Controller upgrade strategy options.
     # rollingUpdate: {}
     # -- (string) Controller upgrade strategy. For Deployments: `Recreate` or
-    # `RollingUpdate`. For StatefulSets: `OnDelete` or `RollingUpdate`. DaemonSets,
+    # `RollingUpdate`. For StatefulSets and DaemonSets: `OnDelete` or `RollingUpdate`.
     # CronJobs and Jobs ignore this field.
     # strategy:
     # -- Apply defaultContainerOptions to initContainers.


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

### Description of the change
<!--
Describe the scope of your change - i.e. what the change does.
Remove any sections that are not applicable.
-->

For now, strategy and rollingUpdate in controllers couldn't work in DaemonSet.  
But this is an important function.  
For example, when you wish to control timings to recreate Pods, you need to set strategy to OnDelete.  
For another case, when you wish non-stop rolling update, you need to set unavailable: 0 and surge: 1 on DaemonSet.

#### Changed
<!-- Any features that have been changed from how they were working before -->

Add to use strategy and rollingUpdate fields on DaemonSet template.

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #681

## Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
